### PR TITLE
Use Docker infrastruture on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,10 @@
 language: python
+# use docker infrastructure
+sudo: false
 install:
   - pip install tox
 script:
-    - tox
+  - tox
 env:
   - TOXENV=py26
   - TOXENV=py27


### PR DESCRIPTION
Docker infra is much faster than VM based one.
We don't need to execute any commands that
require sudo, so we can enable it.